### PR TITLE
Settings: avoid button overlap in legacy UDFPS enroll UI

### DIFF
--- a/res/layout/udfps_enroll_enrolling_non_scroll.xml
+++ b/res/layout/udfps_enroll_enrolling_non_scroll.xml
@@ -78,4 +78,17 @@
         </LinearLayout>
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/side_skip_button"
+        style="@style/FingerprintEnrollSideSkipText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|start"
+        android:layout_marginStart="@dimen/fingerprint_side_skip_margin"
+        android:layout_marginBottom="@dimen/fingerprint_side_skip_margin"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/security_settings_fingerprint_enroll_enrolling_skip"
+        android:visibility="gone" />
+
 </com.android.settings.biometrics.fingerprint.UdfpsEnrollEnrollingView>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -516,6 +516,19 @@
         <item name="android:layout_gravity">start|top</item>
     </style>
 
+    <style name="FingerprintEnrollSideSkipText" parent="@style/TextAppearance.SudGlifBody">
+        <item name="android:layout_gravity">start|top</item>
+        <item name="android:background">@android:color/transparent</item>
+        <item name="android:gravity">start|center_vertical</item>
+        <item name="android:minHeight">40dp</item>
+        <item name="android:paddingStart">8dp</item>
+        <item name="android:paddingEnd">8dp</item>
+        <item name="android:paddingTop">4dp</item>
+        <item name="android:paddingBottom">4dp</item>
+        <item name="android:textColor">?android:attr/textColorPrimary</item>
+        <item name="android:textAlignment">viewStart</item>
+    </style>
+
     <style name="Theme.LockPassword" parent="@style/Theme.Material3.DynamicColors.DayNight">
         <item name="textInputStyle">@style/Widget.Material3.TextInputLayout.OutlinedBox</item>
     </style>

--- a/src/com/android/settings/biometrics/fingerprint/FingerprintEnrollEnrolling.java
+++ b/src/com/android/settings/biometrics/fingerprint/FingerprintEnrollEnrolling.java
@@ -277,6 +277,9 @@ public class FingerprintEnrollEnrolling extends BiometricsEnrollEnrolling {
         // density. Otherwise, the lottie will overlap with the settings header text.
         boolean isLandscape = BiometricUtils.isReverseLandscape(getApplicationContext())
                 || BiometricUtils.isLandscape(getApplicationContext());
+        final boolean useLegacyUdfpsUi = mCanAssumeUdfps
+                && !isLandscape
+                && getResources().getBoolean(R.bool.config_useLegacyUdfpsUi);
 
         updateOrientation((isLandscape
                 ? Configuration.ORIENTATION_LANDSCAPE : Configuration.ORIENTATION_PORTRAIT));
@@ -285,21 +288,19 @@ public class FingerprintEnrollEnrolling extends BiometricsEnrollEnrolling {
         mProgressBar = findViewById(R.id.fingerprint_progress_bar);
         mVibrator = getSystemService(Vibrator.class);
 
-        mFooterBarMixin = getLayout().getMixin(FooterBarMixin.class);
-        mFooterBarMixin.setSecondaryButton(
-                new FooterButton.Builder(this)
-                        .setText(R.string.security_settings_fingerprint_enroll_enrolling_skip)
-                        .setListener(this::onSkipButtonClick)
-                        .setButtonType(FooterButton.ButtonType.SKIP)
-                        .setTheme(com.google.android.setupdesign.R.style.SudGlifButton_Secondary)
-                        .build()
-        );
-
-        // If it's udfps, set the background color only for secondary button if necessary.
-        if (mCanAssumeUdfps) {
+        if (useLegacyUdfpsUi) {
             mShouldSetFooterBarBackground = false;
-            ((UdfpsEnrollEnrollingView) getLayout()).setSecondaryButtonBackground(
-                    getBackgroundColor());
+            ((UdfpsEnrollEnrollingView) getLayout()).showSideSkipButton(this::onSkipButtonClick);
+        } else {
+            mFooterBarMixin = getLayout().getMixin(FooterBarMixin.class);
+            mFooterBarMixin.setSecondaryButton(
+                    new FooterButton.Builder(this)
+                            .setText(R.string.security_settings_fingerprint_enroll_enrolling_skip)
+                            .setListener(this::onSkipButtonClick)
+                            .setButtonType(FooterButton.ButtonType.SKIP)
+                            .setTheme(com.google.android.setupdesign.R.style.SudGlifButton_Secondary)
+                            .build()
+            );
         }
 
         final LayerDrawable fingerprintDrawable = mProgressBar != null

--- a/src/com/android/settings/biometrics/fingerprint/UdfpsEnrollEnrollingView.java
+++ b/src/com/android/settings/biometrics/fingerprint/UdfpsEnrollEnrollingView.java
@@ -32,7 +32,6 @@ import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.Display;
 import android.view.DisplayInfo;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Surface;
 import android.view.View;
@@ -40,14 +39,11 @@ import android.view.ViewGroup;
 import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.view.accessibility.AccessibilityManager;
-import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
-import androidx.annotation.ColorInt;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
@@ -57,7 +53,6 @@ import com.android.settings.flags.Flags;
 import com.android.systemui.biometrics.UdfpsUtils;
 import com.android.systemui.biometrics.shared.model.UdfpsOverlayParams;
 
-import com.google.android.setupcompat.template.FooterBarMixin;
 import com.google.android.setupdesign.GlifLayout;
 import com.google.android.setupdesign.view.BottomScrollView;
 
@@ -80,6 +75,7 @@ public class UdfpsEnrollEnrollingView extends GlifLayout {
 
     private UdfpsEnrollView mUdfpsEnrollView;
     private View mHeaderView;
+    private TextView mSideSkipTextView;
     private AccessibilityManager mAccessibilityManager;
 
     private ObjectAnimator mHeaderScrollAnimator;
@@ -103,6 +99,7 @@ public class UdfpsEnrollEnrollingView extends GlifLayout {
         super.onFinishInflate();
         mHeaderView = findViewById(com.google.android.setupdesign.R.id.sud_landscape_header_area);
         mUdfpsEnrollView = findViewById(R.id.udfps_animation_view);
+        mSideSkipTextView = findViewById(R.id.side_skip_button);
     }
 
     @Override
@@ -282,25 +279,13 @@ public class UdfpsEnrollEnrollingView extends GlifLayout {
         setOnHoverListener();
     }
 
-    void setSecondaryButtonBackground(@ColorInt int color) {
-        // Set the button background only when the button is not under udfps overlay to avoid UI
-        // overlap.
-        if (!mIsLandscape || mShouldUseReverseLandscape) {
+    void showSideSkipButton(@NonNull View.OnClickListener onClickListener) {
+        if (mIsLandscape || mSideSkipTextView == null) {
             return;
         }
-        final Button secondaryButtonView =
-                getMixin(FooterBarMixin.class).getSecondaryButtonView();
-        secondaryButtonView.setBackgroundColor(color);
-        if (mRotation == Surface.ROTATION_90) {
-            secondaryButtonView.setGravity(Gravity.START);
-        } else {
-            secondaryButtonView.setGravity(Gravity.END);
-        }
-        mHeaderView.post(() -> {
-            secondaryButtonView.setLayoutParams(
-                    new LinearLayout.LayoutParams(mHeaderView.getMeasuredWidth(),
-                            ViewGroup.LayoutParams.WRAP_CONTENT));
-        });
+        mSideSkipTextView.setOnClickListener(onClickListener);
+        mSideSkipTextView.setVisibility(View.VISIBLE);
+        mSideSkipTextView.bringToFront();
     }
 
     private void initUdfpsEnrollView(FingerprintSensorPropertiesInternal udfpsProps,

--- a/stub/features/res/values/halcyon_config.xml
+++ b/stub/features/res/values/halcyon_config.xml
@@ -29,6 +29,9 @@
     <!-- Show advanced refresh rate option -->
     <bool name="config_show_advanced_refresh_rate" translatable="false">true</bool>
 
+    <!-- Uses the legacy UDFPS enrollment UI with side text instead of a footer button. -->
+    <bool name="config_useLegacyUdfpsUi" translatable="false">false</bool>
+
     <!-- Show Now Playing -->
     <bool name="config_show_now_playing">false</bool>
 

--- a/stub/features/res/values/halcyon_dimens.xml
+++ b/stub/features/res/values/halcyon_dimens.xml
@@ -15,4 +15,5 @@
 <resources>
     <!-- Fingerprint -->
     <dimen name="fingerprint_find_sensor_padding_top">16dp</dimen>
+    <dimen name="fingerprint_side_skip_margin">24dp</dimen>
 </resources>


### PR DESCRIPTION
The new SUW theme can place the "Do it later" button on top of the fingerprint area on devices with a low-positioned UDFPS

Add a legacy UDFPS UI config and, when enabled in portrait, replace the button with a side-aligned skip text beisde the sensor area ressembling how it was before the SUW theme was changed

Change-Id: Ibdf0715add968138150b438a2ca10890e75bb49c